### PR TITLE
[Demo] Recreate frontend proxy at start

### DIFF
--- a/demo/Makefile
+++ b/demo/Makefile
@@ -12,7 +12,8 @@ DOCKER_COMPOSE_ENV=--env-file .env
 
 .PHONY: start
 start:
-	$(DOCKER_COMPOSE_CMD) $(DOCKER_COMPOSE_ENV) -f docker-compose.yml up --force-recreate --remove-orphans --detach
+	$(DOCKER_COMPOSE_CMD) $(DOCKER_COMPOSE_ENV) build frontendproxy
+	$(DOCKER_COMPOSE_CMD) $(DOCKER_COMPOSE_ENV) up --force-recreate --remove-orphans --detach
 	@echo ""
 	@echo "PromQL Anomaly Detection Demo is running."
 	@echo "Go to http://localhost:8080 for the demo UI."

--- a/demo/docker-compose.yml
+++ b/demo/docker-compose.yml
@@ -249,7 +249,7 @@ services:
 
   # Frontend Proxy (Envoy)
   frontendproxy:
-    image: ${IMAGE_NAME}:${DEMO_VERSION}-frontendproxy
+    image: promql-anomaly-detection-frontendproxy
     container_name: frontend-proxy
     build:
       context: ./


### PR DESCRIPTION
  - The proxy has been modified from upstream to expose prometheus and remove jaeger. For this reason, it needs to be re-built to prevent crashlooping due to missing env vars.
  - Changes the image name to avoid clashing with upstream images.