### PR TITLE
fix upper band for long term of day look back

### DIFF
--- a/rules/recording_rules.yml
+++ b/rules/recording_rules.yml
@@ -134,7 +134,7 @@ groups:
             )
             or
             label_replace(
-                avg_over_time(anomaly:avg_1h[1h] offset 23h30m)
+                avg_over_time(anomaly:select[1h] offset 23h30m)
                 +
                 stddev_over_time(anomaly:select[1h] offset 23h30m)
                         * on() group_left anomaly:stddev_multiplier,


### PR DESCRIPTION
`anomaly:avg_1h` doesn't match to `anomaly:select` due to `record` label, but even despite of this, in accordance with the rest of the logic, here should be just metric average, but not average of average