### PR TITLE
fix: use string for label in adaptive rules

### DIFF
--- a/rules/adaptive.yml
+++ b/rules/adaptive.yml
@@ -51,7 +51,7 @@ groups:
           OR
           {anomaly_name!="", anomaly_select="", anomaly_strategy=~"^$|adaptive"} > 0
         labels:
-          anomaly_select: 1
+          anomaly_select: "1"
           anomaly_strategy: adaptive
 
       # The mid-line used used as the reference to calculate upper and lower bands.


### PR DESCRIPTION
Use string for label in adaptive rules. 

This is also done in the robust rules already. 

Further FluxCD was not happy with just `1` in the label when used as PrometheusRule:
```
monitoring.coreos.com/v1, Kind=PrometheusRule): .spec.groups[name="AnomalyAdaptiveShortTerm"].rules[4].labels.anomaly_select: expected string, got &value.valueUnstructured{Value:1}
```