### PR TITLE
update prediction_type label to long term band

### DIFF
--- a/rules/adaptive.yml
+++ b/rules/adaptive.yml
@@ -99,7 +99,10 @@ groups:
                     "prediction_type", "margin", "", ""
                 )
                 or
-                last_over_time(anomaly:adaptive:lower_band_lt[10m])
+                label_replace(
+                    last_over_time(anomaly:adaptive:lower_band_lt[10m]),
+                    "prediction_type", "long_term", "", ""
+                )
             ),
             0
           )
@@ -118,7 +121,10 @@ groups:
                 "prediction_type", "margin", "", ""
             )
             or
-            last_over_time(anomaly:adaptive:upper_band_lt[10m])
+            label_replace(
+                last_over_time(anomaly:adaptive:upper_band_lt[10m]),
+                "prediction_type", "long_term", "", ""
+            )
           )
 
   # Long term bands are calculated by a different recording rule group with higher interval for efficiency reasons.

--- a/rules/robust.yml
+++ b/rules/robust.yml
@@ -79,7 +79,10 @@ groups:
               "prediction_type", "margin", "", ""
             )
             or
-            last_over_time(anomaly:robust:lower_seasonality_band[10m])
+            label_replace(
+              last_over_time(anomaly:robust:lower_seasonality_band[10m]),
+              "prediction_type", "seasonality", "", ""
+            )
           ),
           0
         )
@@ -98,7 +101,10 @@ groups:
             "prediction_type", "margin", "", ""
           )
           or
-          last_over_time(anomaly:robust:upper_seasonality_band[10m])
+          label_replace(
+            last_over_time(anomaly:robust:upper_seasonality_band[10m]),
+            "prediction_type", "seasonality", "", ""
+          )
         )
 
 - name: AnomalyRobustSeasonal


### PR DESCRIPTION
Problem Statement:
Observed that  the upper bands were not overlaying on the actual metrics before the spikes started for seasonal/recurring spikes, causing alerts to fire.

<img width="2702" height="1404" alt="image (25)" src="https://github.com/user-attachments/assets/45e4c517-5059-496a-b185-41ba5121bfcd" />
<img width="2730" height="1464" alt="image (24)" src="https://github.com/user-attachments/assets/948f18da-b786-4792-9233-39185b6e34a8" />

Root cause:
Found that the final upper band (which is the max of st_stddev based, st_margin based and lt bands), the long term band was getting excluded from the max calculation since promql except it to have the `prediction_type` label which the `st` bands were having, but not the `lt` band.
Once we added that label, upper band started working as excepted.

<img width="2694" height="1524" alt="image (23)" src="https://github.com/user-attachments/assets/bb6244f7-69c3-4b87-9b49-82a540d76435" />
<img width="2712" height="1106" alt="image (22)" src="https://github.com/user-attachments/assets/10d2f72d-99ac-49c6-9260-a70a23fd469d" />

